### PR TITLE
feat: add configurable grants access for district and site admins

### DIFF
--- a/Backend/app/Controllers/Http/ClubsController.ts
+++ b/Backend/app/Controllers/Http/ClubsController.ts
@@ -56,6 +56,7 @@ export default class ClubsController {
       clubEmail: newClub.club_email,
       districtId: newClub.district_id,
       siteUrl: newClub.siteUrl,
+      settings: JSON.stringify(newClub.settings),
     });
     return response.json(true);
   }
@@ -90,6 +91,7 @@ export default class ClubsController {
         clubDescription: updatedClubData.club_description,
         clubEmail: updatedClubData.club_email,
         siteUrl: updatedClubData.siteUrl,
+        settings: JSON.stringify(updatedClubData.settings),
       })
       .save();
     return response.json(true);

--- a/Backend/app/Controllers/Http/ProjectsController.ts
+++ b/Backend/app/Controllers/Http/ProjectsController.ts
@@ -213,16 +213,6 @@ export default class ProjectsController {
    */
   public async paginationFilter({ request, response }: HttpContextContract) {
     const searchCriteria: SearchCriteria = request.input("search_criteria");
-    // const currentPage: number = request.input("current_page");
-    // const limit: number = request.input("limit");
-    // const clubId: number = request.input("club_id");
-    // const searchText: string = request.input("search_text");
-    // const projectStatus: string = request.input("project_status");
-    // const projectRegion: string = request.input("project_region");
-    // const areaOfFocus: string = request.input("area_focus");
-    // const rotaryYear: string = request.input("rotary_year");
-    // const districtId: number | string = request.input("district_id");
-    // const grantType = request.input("grant_type");
     let filteredProjects = await this.filter(searchCriteria);
     return response.json(filteredProjects);
   }

--- a/Backend/app/Controllers/Http/UsersController.ts
+++ b/Backend/app/Controllers/Http/UsersController.ts
@@ -81,7 +81,6 @@ export default class UsersController {
         .where({ user_id: user.userId });
     }
     let club: Clubs = await Clubs.findOrFail(user.clubId);
-    ;
     if (!session.get("userIsLoggedIn")) {
       session.put("userIsLoggedIn", true);
       session.put("lastApiCallTimeStamp", DateTime.now().toMillis());

--- a/Backend/app/Models/Clubs.ts
+++ b/Backend/app/Models/Clubs.ts
@@ -43,6 +43,20 @@ export default class Clubs extends BaseModel {
   @column()
   public clubDescription?: string;
 
+  @column({
+    serialize: (value: string | null) => {
+      if (value) {
+        let parse =
+          typeof value === "object" &&
+          Object.keys(value as unknown as object).length < 1
+            ? "{}"
+            : JSON.stringify(value);
+        return JSON.parse(parse);
+      }
+    },
+  })
+  public settings: string;
+
   @column()
   public siteUrl?: string;
 

--- a/Backend/contracts/util/sharedUtility/classes/RotaryClub.ts
+++ b/Backend/contracts/util/sharedUtility/classes/RotaryClub.ts
@@ -12,5 +12,6 @@ export default class RotaryClub implements IClub {
   site_url= "";
   district_id= 0;
   club_id= 0;
+  settings?: { allowedDsg?: boolean | undefined; allowedDM?: boolean | undefined; allowedGlobal?: boolean | undefined; } | undefined;
   constructor() {}
 }

--- a/Backend/contracts/util/sharedUtility/interfaces/ClubInterface.ts
+++ b/Backend/contracts/util/sharedUtility/interfaces/ClubInterface.ts
@@ -12,4 +12,10 @@ export interface IClub {
   // Creation
   club_id?: number;
   [key: string]: any;
+  // Settings
+  settings?: {
+    allowedDsg?: boolean;
+    allowedDM?: boolean;
+    allowedGlobal?: boolean;
+  };
 } ;

--- a/Backend/database/migrations/1675012832926_clubs.ts
+++ b/Backend/database/migrations/1675012832926_clubs.ts
@@ -15,6 +15,7 @@ export default class extends BaseSchema {
       table.string("club_email", 254).nullable();
       table.string("club_description", 3000).nullable();
       table.string("site_url", 200).nullable();
+      table.jsonb('settings').nullable
       table
         .integer("district_id", 50)
         .unsigned()

--- a/Backend/database/migrations/1684115588037_clubsedits.ts
+++ b/Backend/database/migrations/1684115588037_clubsedits.ts
@@ -1,0 +1,17 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'clubs'
+
+  public async up () {
+    this.schema.alterTable(this.tableName , (table) => {
+      table.jsonb('settings').nullable
+    });
+  }
+  
+  public async down () {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.dropColumn('settings') // drop jsonB column
+    })
+  }
+}

--- a/Frontend/src/components/common/forms/ClubForm.vue
+++ b/Frontend/src/components/common/forms/ClubForm.vue
@@ -70,6 +70,9 @@
           v-if="v$.club.club_email.$error"
           :errorMsg="v$.club.club_email.$errors[0].$message"
         />
+        <BaseCheckBox v-model="club.settings.allowedDsg" label="Disable District Simplified Projects" />
+        <BaseCheckBox v-model="club.settings.allowedDM" label="Disable District Matching Projects" />
+        <BaseCheckBox v-model="club.settings.allowedGlobal" label="Disable Global Projects" />
         <div class="button_row mt-4 flex justify-center gap-4">
           <RotaryButton
             :label="headerFormatter(submitButtonmsg)"

--- a/Frontend/src/components/common/tables/AllClubsInDisctrictTable.vue
+++ b/Frontend/src/components/common/tables/AllClubsInDisctrictTable.vue
@@ -42,7 +42,7 @@
           <td class="px-6 py-4 text-primary-black">
             <div class="buttons_container2 flex gap-2">
               <button
-                v-if="!districtAdminViewProp"
+                v-if="!districtAdminIdViewProp"
                 title="Edit Club"
                 class="crud_buttons hover:text-primary-c"
                 @click="updateClub(club.club_id as number)"
@@ -177,8 +177,7 @@ export default defineComponent({
   emits: ["update:clubId"],
   props: {
     districtIdProp: Number,
-    districtAdminViewProp: Number,
-    clubId: Number,
+    districtAdminIdViewProp: Number,
   },
   data() {
     return {
@@ -201,8 +200,8 @@ export default defineComponent({
     },
   },
   async created() {
-    if (this.districtAdminViewProp) {
-      this.getAllClubsInDistrict(this.districtAdminViewProp || 0);
+    if (this.districtAdminIdViewProp) {
+      this.getAllClubsInDistrict(this.districtAdminIdViewProp || 0);
     } else {
       this.getAllClubsInDistrict(
         this.store.$state.loggedInUsersDistrict.district_id
@@ -212,7 +211,7 @@ export default defineComponent({
   methods: {
     alterpayload(pageAction: number) {
       this.payload.current_page = this.payload.current_page + pageAction;
-      if (this.districtAdminViewProp) {
+      if (this.districtAdminIdViewProp) {
         this.getAllClubsInDistrict();
       } else {
         this.getAllClubsInDistrict(

--- a/Frontend/src/modules/home/views/adminviews/DistrictAdminClubs.vue
+++ b/Frontend/src/modules/home/views/adminviews/DistrictAdminClubs.vue
@@ -30,7 +30,8 @@
     <DistrictClubsTable
       @update:showConfirmModal="updateShowModal"
       @update:clubId="updateClubId"
-    />
+      :districtAdminIdViewProp="store.loggedInUsersDistrict.district_id" 
+      />
     <div class="button_wrapper">
       <RotaryButton label="Create" @click="createNewClub()" />
     </div>

--- a/Frontend/src/modules/home/views/adminviews/MyProjects.vue
+++ b/Frontend/src/modules/home/views/adminviews/MyProjects.vue
@@ -52,14 +52,13 @@
           label="Create Club Project"
           @click="createNewProject('CLUB')"
         />
-
         <RotaryButton
-          v-if="isProjectsOpen == true"
+          v-if="isProjectsOpen == true && !store.$state.loggedInUsersClub.settings?.allowedDsg"
           label="Create Dsg Project"
           @click="createNewProject('DSG')"
         />
         <RotaryButton
-          v-if="isProjectsOpen == true"
+          v-if="isProjectsOpen == true && !store.$state.loggedInUsersClub.settings?.allowedDM"
           label="Create Dm Project"
           @click="createNewProject('DM')"
         />
@@ -113,7 +112,6 @@ export default defineComponent({
       headerFormatter: Utilities.headerFormater,
       tailwind: TAILWIND_COMMON_CLASSES,
       deleteConfirm: null as any,
-      districtAdminViewProp: 0,
       serverException: false,
       expectionObject: {} as IApiException,
       toast: {

--- a/Frontend/src/utils/shared/classes/RotaryClub.ts
+++ b/Frontend/src/utils/shared/classes/RotaryClub.ts
@@ -12,5 +12,10 @@ export default class RotaryClub implements IClub {
   site_url= "";
   district_id= 0;
   club_id= 0;
+  settings= {
+    allowedDsg: false,
+    allowedDM: false,
+    allowedGlobal: false,
+  };
   constructor() {}
 }

--- a/Frontend/src/utils/shared/interfaces/ClubInterface.ts
+++ b/Frontend/src/utils/shared/interfaces/ClubInterface.ts
@@ -12,4 +12,10 @@ export interface IClub {
   // Creation
   club_id?: number;
   [key: string]: any;
+  // Settings
+  settings?: {
+  allowedDsg?: boolean;
+  allowedDM?: boolean;
+  allowedGlobal?: boolean;
+}
 } ;


### PR DESCRIPTION
District and site administrators can now change the grants (dsg, DSM, global) for the clubs in their districts. This has been implemented via a new checkbox interface in the admin panel.